### PR TITLE
chore: add ostruct gem for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ gem 'pg', '~> 1.1'
 # Required for CRA export feature (Mini-FC-02)
 gem 'csv', '~> 3.3'
 
+# Ruby 4.0+ will remove ostruct from default gems
+# Required by rswag-ui (silence warning)
+gem 'ostruct'
+
 gem 'puma', '>= 5.0'
 gem 'rack-cors'
 gem 'rails', '~> 8.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
+    ostruct (0.6.3)
     pagy (9.4.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -414,6 +415,7 @@ DEPENDENCIES
   omniauth
   omniauth-github
   omniauth-google-oauth2
+  ostruct
   pagy (~> 9.0)
   pg (~> 1.1)
   puma (>= 5.0)


### PR DESCRIPTION
## Summary

Add `ostruct` gem to silence rswag-ui warning about ostruct being removed from default gems in Ruby 4.0+.

## Changes

- Add `gem 'ostruct'` to Gemfile

## Why

Ruby 4.0 will remove `ostruct` from default gems. The `rswag-ui` gem uses it but doesn't declare it as a dependency. This fix future-proofs the application.

## Test Results (7 Jan 2026)

| Tool | Result |
|------|--------|
| **RSpec** | 449 examples, 0 failures ✅ |
| **Rswag** | 150 examples, 0 failures ✅ |
| **RuboCop** | 148 files, no offenses ✅ |
| **Brakeman** | 0 Security Warnings ✅ |

## Warning Removed